### PR TITLE
Add Zig versioning requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ An installation script may come soon.
 
 To build from source, clone the repo and run `./build help` for instructions.
 The project currently builds with Zig 0.11.+ and a recent Cargo toolchain. The
-resulting binary for your machine will be produced in `./zig-out/bin/dt`
+resulting binary for your machine will be produced as `./zig-out/bin/dt`
 
 ## The nerdy stuff
 

--- a/build
+++ b/build
@@ -5,8 +5,28 @@ set -euo pipefail
 cd "$(dirname "$0")" || exit 1
 project_root="$(pwd)"
 
+required_zig_version='0.11.0'
+
 help() {
-    >&2 echo "USAGE: $(basename "$0") [build, test, ...]"
+    >&2 echo "USAGE: $(basename "$0") [clean|compile|release|test|cross-clean|cross-release|cross-tar]..."
+    >&2 echo "A simple build will be './build release'"
+    >&2 echo "Compiling requires Zig ${required_zig_version}, and tests require a recent Rust toolchain installation."
+}
+
+require-zig() {
+    # First we check Zig's available
+    if ! command -v zig > /dev/null; then
+        >&2 echo "Zig is not installed or not found on PATH."
+        >&2 echo "Building this project currently requires Zig ${required_zig_version}"
+        exit 1
+    fi
+
+    # Then we check Zig is a version we can build with
+    _zig_version="$(zig version)"
+    if [[ ! ${_zig_version} =~ ^${required_zig_version} ]]; then
+        >&2 echo "Zig ${_zig_version} was found, but only version ${required_zig_version} is supported."
+        exit 1
+    fi
 }
 
 clean() {
@@ -16,16 +36,22 @@ clean() {
 }
 
 compile() {
+    require-zig
+
     zig build
 }
 
 test() {
+    require-zig
+
     zig build test
     cd "$project_root"/old-rust-tests || exit 1
     cargo test
 }
 
 release() {
+    require-zig
+
     zig build -Doptimize=ReleaseSmall
 }
 
@@ -34,6 +60,8 @@ cross-clean() {
 }
 
 cross-release() {
+    require-zig
+
     local triples=(
         aarch64-linux-gnu
         aarch64-linux-musleabi


### PR DESCRIPTION
Folks building from source do not know the version of Zig to use, and the error messages from `./build` in the repo can be confusing. See also #9 

This adds a friendlier message so people don't end up too confused or frustrated.