### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
     .name = "dt",
-    .version = "1.0.0", // Update in main.zig as well
+    .version = "1.0.1", // Update in main.zig as well
     .dependencies = .{},
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,7 +18,7 @@ const DtMachine = interpret.DtMachine;
 const builtins = @import("builtins.zig");
 
 // TODO: Change to @import when it's supported for zon
-pub const version = "1.0.0"; // Update in build.zig.zon as well.
+pub const version = "1.0.1"; // Update in build.zig.zon as well.
 
 const stdlib = @embedFile("stdlib.dt");
 const dtlib = @embedFile("dt.dt");


### PR DESCRIPTION
- Fail ./dt helper script when invoked outside the project root
- Bump to 1.0.1
