### PR TITLE
Namespace definitions from dt.dt, move some things from dt.dt to stdlib.dt

### DIFF
--- a/src/dt.dt
+++ b/src/dt.dt
@@ -3,13 +3,11 @@
 [ [ action flag ]:
   args [ flag eq? ] any?
   action swap do?
-] \handle-flag def
+] \dt/handle-flag def
 
-[ "dt " p version pl ] \print-version def
+[ "dt " p version pl ] \dt/print-version def
 
-[ [ print-version 0 exit ]   "--version" handle-flag ] \--version def
-
-[ print-version
+[ dt/print-version
   [ "USAGE: dt FLAGS CODE..."
     "dt is \"duct tape\" for your unix pipes."
     ""
@@ -17,36 +15,30 @@
     "operations. It can also excel in short shebang scripts, or be explored as"
     "an interactive REPL (read-eval-print loop)."
     ""
-    "More info at https://dt.plumbing"
+    "More info at https:::dt.plumbing"
   ] pls
-] \print-help def
+] \dt/print-help def
 
-[ [ print-help 0 exit ]   "--help" handle-flag ] \--help def
+[ [ dt/print-help 0 exit ]   "--help" dt/handle-flag
+  [ dt/print-version 0 exit ]   "--version" dt/handle-flag
+] \dt/handle-flags def
 
-[ --help --version ] \handle-flags def
-
-[ handle-flags   args unwords eval ] \run-args def!
+[ dt/handle-flags   args unwords eval ] \dt/run-args def!
 
 
 ### PIPE things ###
 
-[ read-lines   run-args ] \pipe-thru-args def!
-
-
-### Shebang things ###
-
-[ args deq swap drop ] \shebang-args def!
+[ read-lines   dt/run-args ] \dt/pipe-thru-args def!
 
 
 ### REPL things ###
 
-[ red "dt " ep version epl   norm inspire epl ] \repl-greet def
+[ red "dt " ep version epl   norm inspire epl ] \dt/repl-greet def
 
+# Definitions only used in the dt REPL
 [ \quit \.q def
   \quit \exit def
   # TODO: define a help command
-] \repl-prelude def
+] \dt/repl-prelude def
 
-[ handle-flags   repl-greet   repl-prelude   repl ] \main-repl def!
-
-[ "» " p   read-line eval   repl ] \repl def!
+[ dt/handle-flags   dt/repl-greet   dt/repl-prelude   repl ] \dt/main-repl def!

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,18 +48,18 @@ pub fn main() !void {
 }
 
 fn handlePipedStdin(dt: *DtMachine) !void {
-    dt.handleCmd("pipe-thru-args") catch |e| return doneOrDie(dt, e);
+    dt.handleCmd("dt/pipe-thru-args") catch |e| return doneOrDie(dt, e);
 }
 
 fn handlePipedStdoutOnly(dt: *DtMachine) !void {
-    dt.handleCmd("run-args") catch |e| return doneOrDie(dt, e);
+    dt.handleCmd("dt/run-args") catch |e| return doneOrDie(dt, e);
 }
 
 fn readEvalPrintLoop(dt: *DtMachine) !void {
-    dt.handleCmd("run-args") catch |e| return doneOrDie(dt, e);
+    dt.handleCmd("dt/run-args") catch |e| return doneOrDie(dt, e);
 
     // TODO: Can this catch be done in the stdlib? Other people need to catch errors too!
-    while (true) dt.handleCmd("main-repl") catch |e| switch (e) {
+    while (true) dt.handleCmd("dt/main-repl") catch |e| switch (e) {
         error.EndOfStream => {
             try stderr.print("\n", .{});
             return;

--- a/src/stdlib.dt
+++ b/src/stdlib.dt
@@ -138,6 +138,12 @@
 \while define
 
 
+### Unixy things ###
+
+[ args deq swap drop ] \shebang-args def!
+[ "» " p   read-line eval   repl ] \repl def!
+
+
 ### Parsing ###
 
 [ lines [ "," split ] map ]


### PR DESCRIPTION
* Namespace definitions from dt.dt
* Move some things from dt.dt to stdlib.dt

Note: This is not establishing an exact syntax for namespacing, or even that namespaces will always be purely determined by name. I think dt does need namespacing. Other characters could be chosen as a delimiter in namespaces like `.`, and also it could potentially be inferred from a filename. In any case... do not take this as "the way!" quite yet