### PR TITLE
Always sort defs.

### DIFF
--- a/src/builtins.zig
+++ b/src/builtins.zig
@@ -328,6 +328,9 @@ pub fn defs(dt: *DtMachine) !void {
         try quote.append(.{ .string = cmdName });
     }
 
+    const items = quote.items;
+    std.mem.sort(DtVal, items, dt, DtVal.isLessThan);
+
     try dt.push(.{ .quote = quote });
 }
 


### PR DESCRIPTION
This is what most humans will want. Other use cases for getting definitions and doing things with them can use either def? for a very fast lookup, or usage to read the information.
