### PR TITLE
Restore asdf/rtx config, restore dev shell script

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+zig master
+

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,4 @@
+This folder contains misc tools used while developing dt.
+
+You probably do not need these!
+

--- a/dev/dt
+++ b/dev/dt
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+DT_ROOT="$(dirname "$0")/.."
+DT="$DT_ROOT/zig-out/bin/dt"
+
+# Running this outside the project root is likely an error:
+if [[ $DT_ROOT != dev/.. ]]; then
+  >&2 echo "ERROR: $0 is intended to be run when developing dt."
+  >&2 echo "If you're just trying to run a dt built from source:"
+  >&2 echo "- Navigate to $DT_ROOT"
+  >&2 echo "- Run './build release' to compile a release executable (Requires Zig 0.11.*)"
+  >&2 echo "- Use the result at: $DT"
+  exit 1
+fi
+
+zig build dt \
+  && >&2 echo 'INFO: dt compiled (zig build exited successfully)' \
+  && exec rlwrap "$DT" "$@"


### PR DESCRIPTION
Too useful to my workflow to leave out.

I moved the dev dt to `dev/dt` so folks don't call it by accident. It retains an error message for anyone lost.

I did try to do this in `dt` instead of `bash` but it's not ready yet. I'd need a way to execute a child process and stream stdin from it. Maybe something like `exec-stream` but I want to think on that and not be hasty