### PR TITLE
Add `stream`, add `rl`/`readln`/`rls`/`readlns`, add example of mutually-recursive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A naive tee implementation:
 ```
 #!/usr/bin/env dt
 
-read-lines unlines   \stdin :
+readln unlines   \stdin :
 args pop   \file :
 
 stdin pl

--- a/demos/red-green.dt
+++ b/demos/red-green.dt
@@ -1,0 +1,9 @@
+#!/usr/bin/env dt
+
+# An example of mutual recursion. Pipe text (or direct a file into) this
+# script. Kinda like `cat` or `lolcat`.
+
+[ rl  red pl  green-line ] \red-line def
+[ rl  green pl  red-line ] \green-line def
+
+red-line

--- a/demos/tee.dt
+++ b/demos/tee.dt
@@ -1,6 +1,6 @@
 #!/usr/bin/env dt
 
-read-lines unlines   \stdin :
+readlns unlines   \stdin :
 args pop   \file :
 
 stdin pl

--- a/src/builtins.zig
+++ b/src/builtins.zig
@@ -63,8 +63,8 @@ pub fn defineAll(machine: *DtMachine) !void {
     try machine.define("norm", "( -- ) Print a control character to reset any styling to standard output and standard error.", .{ .builtin = norm });
     try machine.define(".s", "( -- ) Print the state of the process: all available values.", .{ .builtin = @".s" });
 
-    try machine.define("read-line", "( -- <line> ) Read a string from standard input until newline.", .{ .builtin = @"read-line" });
-    try machine.define("read-lines", "( -- [<line>] ) Read strings, separated by newlines, from standard input until EOF. (For example: until ctrl+d in a Unix-like system, or until a pipe is closed.)", .{ .builtin = @"read-lines" });
+    try machine.define("rl", "( -- <line> ) Read a string from standard input until newline.", .{ .builtin = rl });
+    try machine.define("rls", "( -- [<line>] ) Read strings, separated by newlines, from standard input until EOF. (For example: until ctrl+d in a Unix-like system, or until a pipe is closed.)", .{ .builtin = rls });
     try machine.define("procname", "( -- <name> ) Produce the name of the current process. This can be used, for example, to get the name of a shebang script.", .{ .builtin = procname });
     try machine.define("args", "( -- [<arg>] ) Produce the arguments provided to the process when it was launched.", .{ .builtin = args });
     try machine.define("eval", "( <code> -- ? ) Evaluate a string as dt commands and execute them.", .{ .builtin = eval });
@@ -486,18 +486,18 @@ pub fn @".s"(dt: *DtMachine) !void {
     try stderr.print("]\n", .{});
 }
 
-pub fn @"read-line"(dt: *DtMachine) !void {
+pub fn rl(dt: *DtMachine) !void {
     var line = ArrayList(u8).init(dt.alloc);
     try stdin.streamUntilDelimiter(line.writer(), '\n', null);
 
     try dt.push(.{ .string = line.items });
 }
 
-pub fn @"read-lines"(dt: *DtMachine) !void {
+pub fn rls(dt: *DtMachine) !void {
     var lines = Quote.init(dt.alloc);
 
     while (true) {
-        @"read-line"(dt) catch |err| switch (err) {
+        rl(dt) catch |err| switch (err) {
             error.EndOfStream => break,
             else => return err,
         };

--- a/src/dt.dt
+++ b/src/dt.dt
@@ -12,10 +12,16 @@
     "dt is \"duct tape\" for your unix pipes."
     ""
     "dt can be used in pipes to transform data with general purpose programming"
-    "operations. It can also excel in short shebang scripts, or be explored as"
-    "an interactive REPL (read-eval-print loop)."
+    "operations. It can also excel in short shebang scripts, or be explored as an"
+    "interactive REPL (read-eval-print loop)."
     ""
-    "More info at https:::dt.plumbing"
+    "The default behavior of dt when standard input comes from a pipe is to read all"
+    "lines as a quote of strings. If you need to do something more manual, use stream"
+    "as the first argument."
+    ""
+
+    ""
+    "More info at https://dt.plumbing"
   ] pls
 ] \dt/print-help def
 
@@ -23,12 +29,21 @@
   [ dt/print-version 0 exit ]   "--version" dt/handle-flag
 ] \dt/handle-flags def
 
-[ dt/handle-flags   args unwords eval ] \dt/run-args def!
+[ args unwords words
+  dup len 0 neq?   \has-args:
+  # Drop the first arg if it's 'stream'
+  [ deq swap   \first-arg:
+    first-arg "stream" neq?   \keep:
+    [ first-arg swap enq ] keep do?
+  ] has-args do?
+] \dt/args def
+
+[ dt/handle-flags   dt/args unwords eval ] \dt/run-args def!
 
 
 ### PIPE things ###
 
-[ read-lines   dt/run-args ] \dt/pipe-thru-args def!
+[ readlns   dt/run-args ] \dt/pipe-thru-args def!
 
 
 ### REPL things ###

--- a/src/stdlib.dt
+++ b/src/stdlib.dt
@@ -51,6 +51,14 @@
 \.s \status alias
 
 
+### Reading ###
+
+\rl \read-line alias # Drop in 2.0
+\rl \readln alias
+\rls \read-lines alias # Drop in 2.0
+\rls \readlns alias
+
+
 ### Filesystem and process things ###
 
 [ cwd pl ]
@@ -141,7 +149,7 @@
 ### Unixy things ###
 
 [ args deq swap drop ] \shebang-args def!
-[ "» " p   read-line eval   repl ] \repl def!
+[ "» " p   readln eval   repl ] \repl def!
 
 
 ### Parsing ###
@@ -160,6 +168,6 @@
 
 ### REPL Helpers ###
 
-[ defs [ [ name ]: green name p norm "\t" p name usage pl ] each ]
+[ defs [ [ name ]: green name p   norm "\t" p   name usage pl ] each ]
 "( -- ) Print commands and their usage"
 \help define


### PR DESCRIPTION
* Add `stream` -- Currently behavior is only defined when it is the initial command
  * This closes out #36 
* Add `rl`/`readln`/`rls`/`readlns`
  * Prefer these over `read-line`. They have a symmetry with `pls`/`printlns` and friends so I think `read-line` should go away in a next major version.
* Add an example of mutually-recursive commands