### PR TITLE
Fix comparison ordering in demos/fib.dt

### DIFF
--- a/demos/fib.dt
+++ b/demos/fib.dt
@@ -13,7 +13,7 @@ shebang-args pop to-int \n:
   \usage-fail n not do?
 
 n 1 - \n:
-  \usage-fail 0 n lt? do?
+  \usage-fail n 0 lt? do?
 
 0 pl
 


### PR DESCRIPTION
I think I missed it way back when updating ordering for `lt?` and friends