### PR TITLE
Cross build patch

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) !void {
 
         const cross_install = b.addInstallArtifact(cross);
 
-        const cross_tar = b.addSystemCommand(&.{ "tar", "-czvf", TRIPLE ++ ".tgz", switch (cross.target.cpu_arch.?) {
+        const cross_tar = b.addSystemCommand(&.{ "tar", "--transform", "s|" ++ TRIPLE ++ "|dt|", "-czvf", TRIPLE ++ ".tgz", switch (cross.target.cpu_arch.?) {
             .wasm32 => TRIPLE ++ ".wasm",
             else => TRIPLE,
         } });

--- a/build.zig
+++ b/build.zig
@@ -42,8 +42,6 @@ pub fn build(b: *std.Build) !void {
         cross_step.dependOn(&cross_tar.step);
     }
 
-    b.default_step.dependOn(cross_step);
-
     // Tests
     const test_step = b.step("test", "Run tests");
 


### PR DESCRIPTION
- Don't cross-compile by default
- Use `--transform` during tar so the executable is named correctly for cross targets