### PR TITLE
Deep clones, move newline printers to stdlib, add "beer song" demo

### DIFF
--- a/demos/beer.dt
+++ b/demos/beer.dt
@@ -1,0 +1,15 @@
+#!/usr/bin/env dt
+
+[red "USAGE: beer.dt N" pl norm   1 exit] shebang-args not do?
+
+[ \n:
+  n p " bottles of beer on the wall" pl
+  n p " bottles of beeeer" pl
+  "take one down, pass it around" pl   n 1 - \m:
+  m p " bottles of beer on the wall" pl nl
+  [m bottles] m do? ] \bottles def
+
+shebang-args first \n:
+
+n bottles
+

--- a/src/builtins.zig
+++ b/src/builtins.zig
@@ -58,8 +58,6 @@ pub fn defineAll(machine: *DtMachine) !void {
 
     try machine.define("p", "( <a> -- ) Print the most recent value to standard output.", .{ .builtin = p });
     try machine.define("ep", "( <a> -- ) Print the most recent value to standard error.", .{ .builtin = ep });
-    try machine.define("nl", "( -- ) Print a newline to standard output.", .{ .builtin = nl });
-    try machine.define("enl", "( -- ) Print a newline to standard error.", .{ .builtin = enl });
     try machine.define("red", "( -- ) Print a control character for red to standard output and standard error.", .{ .builtin = red });
     try machine.define("green", "( -- ) Print a control character for green and bold (for the colorblind) to standard output and standard error.", .{ .builtin = green });
     try machine.define("norm", "( -- ) Print a control character to reset any styling to standard output and standard error.", .{ .builtin = norm });
@@ -464,14 +462,6 @@ fn _p(val: DtVal, writer: std.fs.File.Writer) !void {
         .string => |s| try writer.print("{s}", .{s}),
         else => try val.print(writer),
     }
-}
-
-pub fn nl(_: *DtMachine) !void {
-    try stdout.print("\n", .{});
-}
-
-pub fn enl(_: *DtMachine) !void {
-    try stderr.print("\n", .{});
 }
 
 pub fn red(dt: *DtMachine) !void {

--- a/src/stdlib.dt
+++ b/src/stdlib.dt
@@ -20,6 +20,10 @@
 
 # Display: stdout
 
+[ "\n" p ]
+"( -- ) Print a newline to standard output."
+\nl define
+
 [ p nl ]
 "( <a> -- ) Print the most recent value and a newline to standard output."
 \pl define
@@ -33,6 +37,10 @@
 \pls \printlns alias
 
 # Display: stderr
+
+[ "\n" ep ]
+"( -- ) Print a newline to standard error."
+\enl define
 
 [ ep enl ]
 "( <a> -- ) Print the most recent value and a newline to standard error."


### PR DESCRIPTION

- Add an example of "N beers on the wall" song
- Defensively clone to avoid weird edge cases (FIXME!)
- Move nl/enl to stdlib (so rebinds of p/ep take deep effect
