### PR TITLE
docs: fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ configuration files to set an alias that persists will vary by your shell.
 
 [![FlakeHub](https://img.shields.io/endpoint?url=https://flakehub.com/f/so-dang-cool/dt/badge)](https://flakehub.com/flake/so-dang-cool/dt)
 
-More ways to install: https://dt.plumbing/user-guide/tutorial/install.html
+More ways to install: https://dt.plumbing/user-guide/install.html
 
 
 ## Community and resources


### PR DESCRIPTION
https://dt.plumbing/user-guide/tutorial/install.html is 404.
Replace the broken link with https://dt.plumbing/user-guide/install.html .